### PR TITLE
Add additional debugging information for IllegalStateException from Profile (added profile id and pomPath)

### DIFF
--- a/src/main/java/org/l2x6/pom/tuner/model/Module.java
+++ b/src/main/java/org/l2x6/pom/tuner/model/Module.java
@@ -196,13 +196,18 @@ public class Module {
                     }
                 }
             } catch (IOException | XMLStreamException e1) {
-                throw new RuntimeException("Couldnot parse " + pomXml, e1);
+                throw new RuntimeException("Could not parse " + pomXml, e1);
             }
         }
 
-        public Module build() {
-            final List<Profile> useProfiles = Collections
-                    .unmodifiableList(profiles.stream().map(Profile.Builder::build).collect(Collectors.toList()));
+        public Module build() throws IllegalStateException {
+            List<Profile> useProfiles = null;
+            try {
+                useProfiles = Collections
+                        .unmodifiableList(profiles.stream().map(Profile.Builder::build).collect(Collectors.toList()));
+            } catch (IllegalStateException ise) {
+                throw new IllegalStateException("Exception on " + pomPath, ise);
+            }
             profiles = null;
             return new Module(pomPath, moduleGav.build(), parentGav.build(), packaging, name, useProfiles);
         }

--- a/src/main/java/org/l2x6/pom/tuner/model/Profile.java
+++ b/src/main/java/org/l2x6/pom/tuner/model/Profile.java
@@ -84,16 +84,18 @@ public class Profile {
 
             final Map<String, Expression> useProps = Collections.unmodifiableMap(properties.stream() //
                     .map(PropertyBuilder::build) //
-                    .collect( //
-                            Collectors.toMap( //
-                                    e -> e.getKey(), //
-                                    e -> e.getValue(), //
-                                    (u, v) -> {
-                                        throw new IllegalStateException(String.format("Duplicate key %s", u));
-                                    }, //
-                                    LinkedHashMap::new //
-                            ) //
+                    .collect(( //
+                    Collectors.toMap( //
+                            e -> e.getKey(), //
+                            e -> e.getValue(), //
+                            (u, v) -> {
+                                throw new IllegalStateException(
+                                        String.format("Duplicate key %s in profile %s", u, id));
+                            }, //
+
+                            LinkedHashMap::new //
                     ) //
+                    )) //
             );
             this.properties = null;
             return new Profile(id, useChildren, useDependencies, useManagedDependencies, usePlugins,


### PR DESCRIPTION
Hit an IllegalStateException in Profile because of a duplicate property.    Adding some more debugging information (the profile id and the pomPath) so we know what file is causing the error and what profile.